### PR TITLE
Covariance sacc input in compsep

### DIFF
--- a/bbpower/compsep.py
+++ b/bbpower/compsep.py
@@ -114,6 +114,11 @@ class BBCompSep(PipelineStage):
         # Read data
         self.s = sacc.Sacc.load_fits(self.get_input('cells_coadded'))
         self.s_cov = sacc.Sacc.load_fits(self.get_input('cells_coadded_cov'))
+        tr_comb = self.s.get_tracer_combinations()
+        for tr1, tr2 in tr_comb:
+            ind1 = self.s.indices(data_type='cl_bb', tracers=(tr1, tr2))
+            ind2 = self.s_cov.indices(data_type='cl_bb', tracers=(tr1, tr2))
+            assert np.all(ind1 == ind2), "Covariance sacc ordering is wrong"
         if self.use_handl:
             s_fid = sacc.Sacc.load_fits(self.get_input('cells_fiducial'))
             s_noi = sacc.Sacc.load_fits(self.get_input('cells_noise'))

--- a/bbpower/compsep.py
+++ b/bbpower/compsep.py
@@ -20,7 +20,8 @@ class BBCompSep(PipelineStage):
     name = "BBCompSep"
     inputs = [('cells_coadded', FitsFile),
               ('cells_noise', FitsFile),
-              ('cells_fiducial', FitsFile)]
+              ('cells_fiducial', FitsFile),
+              ('cells_coadded_cov', FitsFile)]
     outputs = [('output_dir', DirFile),
                ('config_copy', YamlFile)]
     config_options = {'likelihood_type': 'h&l', 'n_iters': 32,
@@ -112,6 +113,7 @@ class BBCompSep(PipelineStage):
 
         # Read data
         self.s = sacc.Sacc.load_fits(self.get_input('cells_coadded'))
+        self.s_cov = sacc.Sacc.load_fits(self.get_input('cells_coadded_cov'))
         if self.use_handl:
             s_fid = sacc.Sacc.load_fits(self.get_input('cells_fiducial'))
             s_noi = sacc.Sacc.load_fits(self.get_input('cells_noise'))
@@ -127,6 +129,7 @@ class BBCompSep(PipelineStage):
         for c in corr_all:
             if c not in corr_keep:
                 self.s.remove_selection(c)
+                self.s_cov.remove_selection(c)
                 if self.use_handl:
                     s_fid.remove_selection(c)
                     s_noi.remove_selection(c)
@@ -134,6 +137,8 @@ class BBCompSep(PipelineStage):
         # Scale cuts
         self.s.remove_selection(ell__gt=self.config['l_max'])
         self.s.remove_selection(ell__lt=self.config['l_min'])
+        self.s_cov.remove_selection(ell__gt=self.config['l_max'])
+        self.s_cov.remove_selection(ell__lt=self.config['l_min'])
         if self.use_handl:
             s_fid.remove_selection(ell__gt=self.config['l_max'])
             s_fid.remove_selection(ell__lt=self.config['l_min'])
@@ -179,7 +184,7 @@ class BBCompSep(PipelineStage):
 
         # Get power spectra and covariances
         if self.config['bands'] == 'all':
-            if not (self.s.covariance.covmat.shape[-1] == len(self.s.mean) == self.n_bpws * self.ncross):
+            if not (self.s_cov.covariance.covmat.shape[-1] == len(self.s.mean) == self.n_bpws * self.ncross):
                 raise ValueError("C_ell vector's size is wrong")
 
         v2d = np.zeros([self.n_bpws, self.ncross])
@@ -217,7 +222,7 @@ class BBCompSep(PipelineStage):
                 pol2b = self.pols[p2b].lower()
                 cl_typb = f'cl_{pol1b}{pol2b}'
                 ind_b = self.s.indices(cl_typb, (t1b, t2b))
-                cv2d[:, ind_vec, :, ind_vecb] = self.s.covariance.covmat[ind_a][:, ind_b]
+                cv2d[:, ind_vec, :, ind_vecb] = self.s_cov.covariance.covmat[ind_a][:, ind_b]
 
         # Store data
         self.bbdata = self.vector_to_matrix(v2d)

--- a/test/run_compsep_test.sh
+++ b/test/run_compsep_test.sh
@@ -6,7 +6,8 @@ mkdir -p test/test_out
 python ./examples/generate_SO_spectra.py test/test_out
 
 # Run pipeline
-python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cls_coadd.fits   --cells_noise=./test/test_out/cls_noise.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --output_dir=./test/test_out   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config.yml
+python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cls_coadd.fits   --cells_noise=./test/test_out/cls_noise.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --cells_coadded_cov=./test/test_out/cls_coadd.fits
+--output_dir=./test/test_out   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config.yml
 
 # Check chi2
 if python -c "import numpy as np; chi2=np.load('test/test_out/param_chains.npz')['chi2']; assert chi2<1E-5"; then

--- a/test/run_polychord_test.sh
+++ b/test/run_polychord_test.sh
@@ -18,7 +18,7 @@ python -m bbpower BBPowerSpecter   --splits_list=./examples/test_data/splits_lis
 
 python -m bbpower BBPowerSummarizer   --splits_list=./examples/test_data/splits_list.txt   --bandpasses_list=./examples/data/bpass_list.txt   --cells_all_splits=./test/test_out/cells_all_splits.fits   --cells_all_sims=./test/test_out/cells_all_sims.txt   --cells_coadded_total=./test/test_out/cells_coadded_total.fits   --cells_coadded=./test/test_out/cells_coadded.fits   --cells_noise=./test/test_out/cells_noise.fits   --cells_null=./test/test_out/cells_null.fits   --config=./test/test_config_polychord.yml
 
-python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cells_coadded.fits   --cells_noise=./test/test_out/cells_noise.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --output_dir=./test/test_out  --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_polychord.yml
+python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cells_coadded.fits   --cells_noise=./test/test_out/cells_noise.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --cells_coadded_cov=./test/test_out/cells_coadded.fits   --output_dir=./test/test_out  --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_polychord.yml
 
 python examples/polychord_plot_triangle.py 
 

--- a/test/run_power_specter_test.sh
+++ b/test/run_power_specter_test.sh
@@ -18,7 +18,7 @@ python -m bbpower BBPowerSpecter   --splits_list=./examples/test_data/splits_lis
 
 python -m bbpower BBPowerSummarizer   --splits_list=./examples/test_data/splits_list.txt   --bandpasses_list=./examples/data/bpass_list.txt   --cells_all_splits=./test/test_out/cells_all_splits.fits   --cells_all_sims=./test/test_out/cells_all_sims.txt   --cells_coadded_total=./test/test_out/cells_coadded_total.fits   --cells_coadded=./test/test_out/cells_coadded.fits   --cells_noise=./test/test_out/cells_noise.fits   --cells_null=./test/test_out/cells_null.fits   --config=./test/test_config_emcee.yml
 
-python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cells_coadded.fits   --cells_noise=./test/test_out/cells_noise.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --output_dir=./test/test_out   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_emcee.yml
+python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cells_coadded.fits   --cells_noise=./test/test_out/cells_noise.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --cells_coadded_cov=./test/test_out/cells_coadded.fits   --output_dir=./test/test_out   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_emcee.yml
 
 python -m bbpower BBPlotter   --cells_coadded_total=./test/test_out/cells_coadded_total.fits   --cells_coadded=./test/test_out/cells_coadded.fits   --cells_noise=./test/test_out/cells_noise.fits   --cells_null=./test/test_out/cells_null.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --param_chains=./test/test_out/emcee.npz   --plots=./test/test_out/plots.dir   --plots_page=./test/test_out/plots_page.html   --config=./test/test_config_emcee.yml
 

--- a/test/run_predicted_spectra_test.sh
+++ b/test/run_predicted_spectra_test.sh
@@ -7,7 +7,7 @@ mkdir -p test/test_out
 python ./examples/generate_SO_spectra.py test/test_out
 
 # This computes the predicted spectra from the MAP parameters
-python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cls_coadd.fits   --cells_noise=./test/test_out/cls_coadd.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --output_dir=./test/test_out   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_predicted_spectra.yml
+python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cls_coadd.fits   --cells_noise=./test/test_out/cls_coadd.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --cells_coadded_cov=./test/test_out/cls_coadd.fits   --output_dir=./test/test_out   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_predicted_spectra.yml
 
 # Check the predicted spectra exist
 if [ ! -f ./test/test_out/cells_model.npz ]; then

--- a/test/run_sampling_test.sh
+++ b/test/run_sampling_test.sh
@@ -8,7 +8,7 @@ python ./examples/generate_SO_spectra.py test/test_out
 
 # Run pipeline
 # This runs the likelihood sampler
-python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cls_coadd.fits   --cells_noise=./test/test_out/cls_coadd.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --param_chains=./test/test_out/param_chains.npz   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_sampling.yml
+python -m bbpower BBCompSep   --cells_coadded=./test/test_out/cls_coadd.fits   --cells_noise=./test/test_out/cls_coadd.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --cells_coadded_cov=./test/test_out/cls_coadd.fits   --param_chains=./test/test_out/param_chains.npz   --config_copy=./test/test_out/config_copy.yml   --config=./test/test_config_sampling.yml
 
 # This plots the results of the pipeline
 python -m bbpower BBPlotter   --cells_coadded_total=./test/test_out/cls_coadd.fits   --cells_coadded=./test/test_out/cls_coadd.fits   --cells_noise=./test/test_out/cls_coadd.fits   --cells_null=./test/test_out/cls_coadd.fits   --cells_fiducial=./test/test_out/cls_fid.fits   --param_chains=./test/test_out/param_chains.npz   --plots=./test/test_out/plots.dir   --plots_page=./test/test_out/plots_page.html   --config=./test/test_config_sampling.yml


### PR DESCRIPTION
This allows us to have mock data without covariance matrix attached, so we don't need to store the same covariance over and over again when dealing with a set of realizations. Instead, the covariance is read from another sacc file (`cells_coadded_cov`).