### PR TITLE
Option to save model to sacc file

### DIFF
--- a/bbpower/compsep.py
+++ b/bbpower/compsep.py
@@ -285,8 +285,9 @@ class BBCompSep(PipelineStage):
 
             if comp['decorr']:
                 d_amp = params[comp['decorr_param_names']['decorr_amp']]
-                d_nu0 = params[comp['decorr_param_names']['decorr_nu0']]
-                decorr_delta = d_amp**(1./np.log(d_nu0)**2)
+                d_nu01 = params[comp['decorr_param_names']['decorr_nu01']]
+                d_nu02 = params[comp['decorr_param_names']['decorr_nu02']]
+                decorr_delta = d_amp**(1./np.log(d_nu01/d_nu02)**2)
                 for f1 in range(self.nfreqs):
                     for f2 in range(f1, self.nfreqs):
                         sed_12 = decorrelated_bpass(self.bpss[f1],


### PR DESCRIPTION
Implements a `"sampler"` that simply creates a sacc file with the desired model.

In doing this I realised we currently have a bug with how frequency decorrelation was originally implemented. Thankfully this does not affect any of our published results (since none of them used this model), but it would be good to get this fixed ASAP.